### PR TITLE
Need to update APAC rubygems mirror.

### DIFF
--- a/cookbooks/rubygems-balancer/templates/default/site.conf.erb
+++ b/cookbooks/rubygems-balancer/templates/default/site.conf.erb
@@ -16,19 +16,19 @@ server {
   <% else %>
 
     if ($geoip_country_code = "CN") {
-      set $gem_mirror http://au-m.rubygems.org;
+      set $gem_mirror http://mirror.ninefold.com;
     }
 
     if ($geoip_country_code = "JP") {
-      set $gem_mirror http://au-m.rubygems.org;
+      set $gem_mirror http://mirror.ninefold.com;
     }
 
     if ($geoip_country_code = "AU") {
-      set $gem_mirror http://au-m.rubygems.org;
+      set $gem_mirror http://mirror.ninefold.com;
     }
 
     if ($geoip_country_code = "NZ") {
-      set $gem_mirror http://au-m.rubygems.org;
+      set $gem_mirror http://mirror.ninefold.com;
     }
 
     if ($continent = "EU") {
@@ -165,19 +165,19 @@ server {
   server_name <%= @server_names.join(" ") %>;
 
   if ($geoip_country_code = "CN") {
-    set $gem_mirror_ssl https://au-m.rubygems.org;
+    set $gem_mirror_ssl https://mirror.ninefold.com;
   }
 
   if ($geoip_country_code = "JP") {
-    set $gem_mirror_ssl https://au-m.rubygems.org;
+    set $gem_mirror_ssl https://mirror.ninefold.com;
   }
 
   if ($geoip_country_code = "AU") {
-    set $gem_mirror_ssl https://au-m.rubygems.org;
+    set $gem_mirror_ssl https://mirror.ninefold.com;
   }
 
   if ($geoip_country_code = "NZ") {
-    set $gem_mirror_ssl https://au-m.rubygems.org;
+    set $gem_mirror_ssl https://mirror.ninefold.com;
   }
 
   if ($continent = "EU") {


### PR DESCRIPTION
I work for ninefold who essentially maintains the the old au-m.rubygems.org. (Or the server it was hosted on)

This server needs to be shut down. A new mirror has been built at the URL:
mirror.ninefold.com

Please either change this record or update the CNAME on your end.
