### PR TITLE
Include default sensu recipe

### DIFF
--- a/cookbooks/rubygems-sensu/attributes/default.rb
+++ b/cookbooks/rubygems-sensu/attributes/default.rb
@@ -1,0 +1,3 @@
+default['sensu']['version'] = '0.14.0-1'
+default['sensu']['use_ssl'] = false
+node.default['sensu']['use_embedded_ruby'] = true

--- a/cookbooks/rubygems-sensu/attributes/default.rb
+++ b/cookbooks/rubygems-sensu/attributes/default.rb
@@ -1,3 +1,3 @@
 default['sensu']['version'] = '0.14.0-1'
 default['sensu']['use_ssl'] = false
-node.default['sensu']['use_embedded_ruby'] = true
+default['sensu']['use_embedded_ruby'] = true

--- a/cookbooks/rubygems-sensu/metadata.rb
+++ b/cookbooks/rubygems-sensu/metadata.rb
@@ -1,7 +1,7 @@
 name 'rubygems-sensu'
 maintainer 'RubyGems.org ops team'
 
-version '0.1.5'
+version '0.1.6'
 
 depends 'build-essential'
 depends 'chef-vault'

--- a/cookbooks/rubygems-sensu/recipes/default.rb
+++ b/cookbooks/rubygems-sensu/recipes/default.rb
@@ -3,9 +3,6 @@
 # Recipe:: default
 #
 
-node.default['sensu']['version'] = '0.14.0-1'
-node.default['sensu']['use_ssl'] = false
-
 include_recipe 'sensu'
 
 # this will only ever return a single 'ip' key since node comes from

--- a/cookbooks/rubygems-sensu/recipes/server.rb
+++ b/cookbooks/rubygems-sensu/recipes/server.rb
@@ -12,6 +12,8 @@ node.default['uchiwa']['settings']['user'] = sensu_creds['user']
 node.default['uchiwa']['settings']['pass'] = sensu_creds['password']
 node.default['sensu']['use_embedded_ruby'] = true
 
+include_recipe 'sensu::default'
+
 sensu_handler 'default' do
   type 'pipe'
   command 'cat'

--- a/cookbooks/rubygems-sensu/recipes/server.rb
+++ b/cookbooks/rubygems-sensu/recipes/server.rb
@@ -10,7 +10,6 @@ sensu_creds = chef_vault_item('sensu', 'credentials')
 node.default['uchiwa']['version'] = '0.2.6-1'
 node.default['uchiwa']['settings']['user'] = sensu_creds['user']
 node.default['uchiwa']['settings']['pass'] = sensu_creds['password']
-node.default['sensu']['use_embedded_ruby'] = true
 
 include_recipe 'sensu::default'
 


### PR DESCRIPTION
From https://github.com/sensu/sensu-chef#sensudefault
This recipe must be included before any of the Sensu LWRP's can be used

Without it `rubygems-monitoring::default` failed on first run with:
```
Error executing action `create` on resource
'file[/etc/sensu/conf.d/handlers/default.json]'
```