### PR TITLE
Fix public db backups

### DIFF
--- a/cookbooks/rubygems-backups/templates/default/public_postgresql.rb.erb
+++ b/cookbooks/rubygems-backups/templates/default/public_postgresql.rb.erb
@@ -16,7 +16,7 @@ Backup::Model.new(:public_postgresql, 'RubyGems.org Public Database Dump') do
     db.password    = "<%= @postgresql_password %>"
     db.host        = "localhost"
     db.port        = 5432
-    db.only_tables = ['rubygems', 'versions' 'dependencies', 'linksets', 'requirements', 'version_histories']
+    db.only_tables = ['rubygems', 'versions', 'dependencies', 'linksets', 'requirements', 'version_histories']
   end
 
   compress_with Gzip

--- a/cookbooks/rubygems-backups/templates/default/public_postgresql.rb.erb
+++ b/cookbooks/rubygems-backups/templates/default/public_postgresql.rb.erb
@@ -16,7 +16,7 @@ Backup::Model.new(:public_postgresql, 'RubyGems.org Public Database Dump') do
     db.password    = "<%= @postgresql_password %>"
     db.host        = "localhost"
     db.port        = 5432
-    db.only_tables = ['rubygems', 'versions', 'dependencies', 'linksets', 'requirements', 'version_histories']
+    db.only_tables = ['rubygems', 'versions', 'dependencies', 'linksets', 'version_histories']
   end
 
   compress_with Gzip


### PR DESCRIPTION
A missing comma in the 'only_tables' directive caused the Backup DSL to interpret the table name as 'versionsdependencies', so the pgdump command was 
`/usr/local/bin/pg_dump  --host='localhost' --port='5432'  --table='rubygems' --table='versionsdependencies' --table='linksets' --table='requirements' --table='version_histories'  gemcutter_test"` and the versions and dependencies table wasn't being backed up.

I also removed the requirements table from the public dump as it is no longer a table in the rubygems.org schema, and any data there would be leftover before the migration and  out of date anyway.