### PR TITLE
Reduce the amount of logs we keep around to 30 days

### DIFF
--- a/cookbooks/rubygems-balancer/recipes/logrotate.rb
+++ b/cookbooks/rubygems-balancer/recipes/logrotate.rb
@@ -6,7 +6,7 @@
 logrotate_app 'nginx' do
   path "#{node['nginx']['log_dir']}/*.log"
   frequency 'daily'
-  rotate 52
+  rotate 30
   options %w(missingok compress delaycompress notifempty sharedscripts)
   postrotate "    [ -f #{node['nginx']['pid']} ] && kill -USR1 `cat #{node['nginx']['pid']}`"
   create '0640 www-data adm'


### PR DESCRIPTION
This will relieve a lot of the alerts we've been getting with disk usage on LBs

/cc @rubygems/infrastructure