### PR TITLE
Remove proxy pass for Bundler API

### DIFF
--- a/cookbooks/rubygems-balancer/templates/default/site.conf.erb
+++ b/cookbooks/rubygems-balancer/templates/default/site.conf.erb
@@ -236,11 +236,6 @@ server {
     rewrite ^ /gems/$gem.gem redirect;
   }
 
-  location /api/v1/dependencies {
-    proxy_set_header Host bundler.rubygems.org;
-    proxy_pass http://bundler.rubygems.org;
-  }
-
   location /quick/Marshal.4.8/ {
     rewrite ^ $gem_mirror_ssl$request_uri redirect;
   }


### PR DESCRIPTION
*\* DO NOT MERGE UNTIL [rubygems/rubygems.org#966](https://github.com/rubygems/rubygems.org/pull/966) is pulled in.

This removes the nginx proxy which passes rubygems.org requests to the Bundler API.
