### PR TITLE
Add CORS header to GET and OPTIONS application requests

### DIFF
--- a/cookbooks/rubygems-balancer/templates/default/site.conf.erb
+++ b/cookbooks/rubygems-balancer/templates/default/site.conf.erb
@@ -142,6 +142,9 @@ server {
     }
 
     location @app {
+      add_header Access-Control-Allow-Origin *
+      add_header Access-Control-Allow-Methods GET, OPTIONS
+
       proxy_pass http://app_servers;
     }
 
@@ -300,6 +303,9 @@ server {
   }
 
   location @app {
+    add_header Access-Control-Allow-Origin *
+    add_header Access-Control-Allow-Methods GET, OPTIONS
+
     proxy_pass http://app_servers;
   }
 


### PR DESCRIPTION
I don't know how to Nginx, but this seems to be the solution proposed for Rubygems.org CORS/JSONP support: https://github.com/rubygems/rubygems.org/pull/592

The location block may need to be changed, I'm not sure what exactly we need to give CORS access to. The app servers seem the most likely to me, but I don't know enough about Rubygems.org to be 100% sure.