### PR TITLE
Enable OCSP stapling on the balancer

### DIFF
--- a/cookbooks/rubygems-balancer/templates/default/site.conf.erb
+++ b/cookbooks/rubygems-balancer/templates/default/site.conf.erb
@@ -179,6 +179,11 @@ server {
   ssl_session_cache           off;
   keepalive_timeout           65;
 
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  resolver 8.8.8.8 8.8.4.4 valid=300s;
+  resolver_timeout 5s;
+
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto https;
   proxy_set_header Content-Length $content_length;


### PR DESCRIPTION
Caveat: I'm not sure if outbound connections to the OCSPs are currently allowed or blocked by a firewall or something. I believe it can be checked by seeing if the following one-liner emits some OCSP urls: 

```
OLDIFS=$IFS; IFS=':' certificates=$(openssl s_client -connect google.com:443 -showcerts -tlsextdebug -tls1 2>&1 </dev/null | sed -n '/-----BEGIN/,/-----END/ {/-----BEGIN/ s/^/:/; p}'); for certificate in ${certificates#:}; do echo $certificate | openssl x509 -noout -ocsp_uri; done; IFS=$OLDIFS
```

(one liner from [here](https://raymii.org/s/tutorials/OCSP_Stapling_on_nginx.html))
