### PR TITLE
Add recipe to run script/shoryuken

### DIFF
--- a/cookbooks/rubygems-app/recipes/logrotate.rb
+++ b/cookbooks/rubygems-app/recipes/logrotate.rb
@@ -11,6 +11,7 @@ logrotate_app 'rails' do
   options %w(missingok nocreate compress delaycompress dateext notifempty sharedscripts)
   postrotate [
     '    [ -f /etc/service/unicorn/supervise/pid ] && kill -USR1 `cat /etc/service/unicorn/supervise/pid`',
-    '    [ -f /etc/service/delayed_job/supervise/pid ] && sv -w 30 restart delayed_job'
+    '    [ -f /etc/service/delayed_job/supervise/pid ] && sv -w 30 restart delayed_job',
+    '    [ -f /etc/service/shoryuken/supervise/pid ] && sv -w 30 restart shoryuken'
   ]
 end

--- a/cookbooks/rubygems-app/recipes/shoryuken.rb
+++ b/cookbooks/rubygems-app/recipes/shoryuken.rb
@@ -3,12 +3,15 @@
 # Recipe:: shoryuken
 #
 
+secrets = chef_vault_item('rubygems', node.chef_environment)
+
 runit_service 'shoryuken' do
   owner 'deploy'
   group 'deploy'
   default_logger true
   env(
-    'RAILS_ENV' => node.chef_environment
+    'RAILS_ENV' => node.chef_environment,
+    'SQS_QUEUE' => secrets['stats_sqs_queue']
   )
   options(
     owner: 'deploy',

--- a/cookbooks/rubygems-app/recipes/shoryuken.rb
+++ b/cookbooks/rubygems-app/recipes/shoryuken.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: rubygems-app
+# Recipe:: shoryuken
+#
+
+runit_service 'shoryuken' do
+  owner 'deploy'
+  group 'deploy'
+  default_logger true
+  env(
+    'RAILS_ENV' => node.chef_environment
+  )
+  options(
+    owner: 'deploy',
+    group: 'deploy',
+    bundle_command: '/usr/local/bin/bundle',
+    rails_env: node.chef_environment
+  )
+  action ::File.exist?('/applications/rubygems/current') ? :enable : :disable
+end
+
+sudo 'deploy-shoryuken' do
+  user 'deploy'
+  commands [
+    '/etc/init.d/shoryuken *',
+    '/usr/sbin/service shoryuken *',
+    '/usr/bin/sv -w * shoryuken'
+  ]
+  nopasswd true
+end

--- a/cookbooks/rubygems-app/templates/default/sv-shoryuken-run.erb
+++ b/cookbooks/rubygems-app/templates/default/sv-shoryuken-run.erb
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd /applications/rubygems/current
+
+exec 2>&1
+exec <%= node['runit']['chpst_bin'] %> \
+  -u <%= @options[:owner] %>:<%= @options[:group] %> \
+  -e <%= node['runit']['sv_dir'] %>/shoryuken/env \
+  <%= @options[:bundle_command] %> exec \
+  bin/shoryuken-worker


### PR DESCRIPTION
The config was copied from the delayed_job recipe.

We want to run shoryuken as part of #35.

## Prerequisites

- [x] deploy rubygems/rubygems.org#1176, which adds `bin/shoryuken-worker`. This will fail otherwise.