### PR TITLE
Add sensu check for rubygems ssl cerificate verification

### DIFF
--- a/cookbooks/rubygems-sensu/files/default/check_rubygems_ssl.rb
+++ b/cookbooks/rubygems-sensu/files/default/check_rubygems_ssl.rb
@@ -1,0 +1,77 @@
+#! /usr/bin/env ruby
+#
+#   Check Rubygems SSL
+#
+# DESCRIPTION:
+#   Check whether a connection can be established with host using the
+#   SSL certificate which comes bundled with rubygems
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#    == If you are passing a glob inclose it in quotes ('')
+#   ./check_rubygems_ssl.rb -P './path_to_rubygems/ssl_certs/*/*.pem' -h rubygems.org
+#
+
+require 'openssl'
+require 'net/http'
+require 'sensu-plugin/check/cli'
+
+class CheckRubygemsSSL < Sensu::Plugin::Check::CLI
+  option :pem,
+         description: 'Path/Glob to PEM file.',
+         short: '-P',
+         long: '--pem PEM'
+
+  option :host,
+         description: 'Host to validate against',
+         short: '-h',
+         long: '--host HOST'
+
+  def bundled_certificate_store(ssl_cert_glob)
+    store = OpenSSL::X509::Store.new
+
+    Dir[ssl_cert_glob].each do |ssl_cert|
+      store.add_file ssl_cert
+    end
+
+    store
+  end
+
+  def validate_opts
+    if !config[:pem] || !config[:host]
+      unknown 'Path to pem is required' unless config[:pem]
+      unknown 'Host name is required' unless config[:host]
+    elsif config[:pem]
+      unknown 'No such cert found' if Dir.glob(config[:pem]).empty?
+    end
+  end
+
+  def verify_ok_response(response)
+    if response.code == '200'
+      ok 'Certificate shall pass'
+    else
+      warning "Something went wrong while verifing #{config[:host]}: #{response.inspect}"
+    end
+  end
+
+  def run
+    validate_opts
+    http = Net::HTTP.new(config[:host], 443)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    http.cert_store = bundled_certificate_store(config[:pem])
+    response = http.get('/')
+    verify_ok_response(response)
+  rescue Errno::ENOENT, Errno::ETIMEDOUT
+    warning "#{config[:host]} seems offline, I can't tell whether ssl would work."
+  rescue OpenSSL::SSL::SSLError => e
+    # Only fail for certificate verification errors
+    if e.message =~ /certificate verify failed/
+      critical "#{config[:host]} is not verifiable using the included certificates. Error was: #{e.message}"
+    else
+      warning "Something went wrong while verifing #{config[:host]}: e.message"
+    end
+  end
+end

--- a/cookbooks/rubygems-sensu/recipes/default.rb
+++ b/cookbooks/rubygems-sensu/recipes/default.rb
@@ -38,6 +38,7 @@ package 'postgresql-client'
   check-procs.rb
   check_postgres.pl
   check_apt.sh
+  check_rubygems_ssl.rb
 ).each do |plugin|
   cookbook_file "/etc/sensu/plugins/#{plugin}" do
     source plugin

--- a/cookbooks/rubygems-sensu/recipes/monitoring.rb
+++ b/cookbooks/rubygems-sensu/recipes/monitoring.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: rubygems-sensu
+# Recipe:: monitoring
+#
+
+%w(
+  rubygems.org
+  fastly.rubygems.org
+  rubygems.global.ssl.fastly.net
+  staging.rubygems.org
+  index.rubygems.org
+).each do |host|
+  sensu_check "check_#{host}_ssl" do
+    command "perl /etc/sensu/plugins/check_postgres_backends.rb -P '' -h #{host}"
+    handlers ['slack', 'pagerduty']
+    subscribers ['app']
+    interval 120
+    additional(occurrences: 3)
+  end
+end

--- a/cookbooks/rubygems-sensu/recipes/server.rb
+++ b/cookbooks/rubygems-sensu/recipes/server.rb
@@ -30,5 +30,6 @@ include_recipe 'rubygems-sensu::balancer'
 include_recipe 'rubygems-sensu::base'
 include_recipe 'rubygems-sensu::database'
 include_recipe 'rubygems-sensu::nginx'
+include_recipe 'rubygems-sensu::monitoring'
 
 include_recipe 'rubygems-sensu::uchiwa'


### PR DESCRIPTION
Name I have used for [sensu_check](https://sensuapp.org/docs/latest/reference/checks.html#check-names) is valid:
> Validated with Ruby regex /^[\w\.-]+$/.match("check-name")

Test is copied from: https://github.com/rubygems/rubygems/blob/9b1c9584ea5d9299ec28aa669de1218540a2210d/test/rubygems/test_bundled_ca.rb