### PR TITLE
Remove Client-IP header from requests

### DIFF
--- a/cookbooks/rubygems-balancer/templates/default/site.conf.erb
+++ b/cookbooks/rubygems-balancer/templates/default/site.conf.erb
@@ -39,6 +39,7 @@ server {
 
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Client-IP "";
     proxy_set_header Host $host;
     proxy_redirect off;
 
@@ -206,6 +207,7 @@ server {
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Proto $scheme_from_fastly;
+  proxy_set_header Client-IP "";
   proxy_set_header Content-Length $content_length;
   proxy_set_header Host $host;
   proxy_redirect off;


### PR DESCRIPTION
Client-IP header is added by local proxy of some users (contains
private ip of user) and raises IpSpoofAttackError in app when
X-Forwarded-For doesn't match Client-IP.